### PR TITLE
Fix imputation

### DIFF
--- a/exercises/Dimensionality_Reduction/02_Nonlinear_dimensionality_reduction.ipynb
+++ b/exercises/Dimensionality_Reduction/02_Nonlinear_dimensionality_reduction.ipynb
@@ -78,11 +78,11 @@
     "#### What is tSNE?\n",
     "t-SNE is the most popular visualization method for single cell RNA-sequencing data. The method was first introduced by Laurens van der Maaten in 2008 in the aptly named article [\"Visualizing High-Dimensional Data Using t-SNE\"](http://jmlr.org/papers/v9/vandermaaten08a.html). The goal of t-SNE is to produce a two or three dimensional embedding of a dataset that exists in many dimensions such that the embedding can be used for visualization.\n",
     "\n",
-    "By embedding, we're talking about projecting the data from high dimensions onto vectors in a smaller space.\n",
+    "By embedding, we're talking about projecting the data from high dimensional space onto vectors in a smaller dimensional space.\n",
     "\n",
     "The way t-SNE does this is by minimizing the difference between neighborhood distances (i.e. distances from a cell to a set of close cells) in the original high dimensional space and the lower dimensional embedding space. t-SNE is an optimization problem where the algorithm iteratively learns a series of transformations such that each successive transformation better minimizes this difference between the high and low dimensional neighborhood distances. \n",
     "\n",
-    "This approach preserves local structure in the data. Cells that are close in high dimensional space (i.e. have small Euclidean distances) will also be close in low dimensional space. However, it also means that global structure will not be preserved. This means that the distance between \"clusters\" in a t-SNE plot don't have any meaning.\n",
+    "This approach preserves local structure in the data. Cells that are close in high dimensional space (i.e. have small Euclidean distances) will also be close in low dimensional space. However, it also means that global structure *will not* be preserved. This means that the distance between \"clusters\" in a t-SNE plot don't have any meaning.  In other words, the white-space on the graph has *no* interpretative value.\n",
     "\n",
     "\n",
     "#### How to use t-SNE effectively\n",
@@ -151,7 +151,9 @@
     "import sklearn.manifold\n",
     "tsne_op = sklearn.manifold.TSNE(n_components=2, perplexity=30)\n",
     "data_tsne = tsne_op.fit_transform(data)\n",
-    "```"
+    "```\n",
+    "\n",
+    "**Note**: In the example below we are instantiating the `tsne_op` with default parameters."
    ]
   },
   {
@@ -204,7 +206,7 @@
    "source": [
     "# ==============\n",
     "# experiment with the perplexity parameter\n",
-    "tsne_op = sklearn.manifold.TSNE(perplexity=\n",
+    "tsne_op = sklearn.manifold.TSNE(perplexity= ) # <-\n",
     "data_tsne =\n",
     "# =============="
    ]
@@ -232,7 +234,7 @@
    "source": [
     "## 3. UMAP\n",
     "\n",
-    "Even though UMAP is not a part of scikit-learn, the syntax for UMAP is identical to t-SNE: `umap.UMAP().fit_transform`. UMAP is relatively fast, so you won't need to use the subsampled data. We also don't need to do PCA beforehand, but since we've already done it we may as well."
+    "Even though UMAP is not a part of scikit-learn, the syntax for UMAP is identical to t-SNE: `umap.UMAP().fit_transform`. UMAP is relatively fast, so you won't need to use the subsampled data. We also don't need to do PCA beforehand, but since we've already done it we may as well use it."
    ]
   },
   {
@@ -361,7 +363,9 @@
     "2. How might you determine which method is closest to the ground truth?\n",
     "3. Which parameters are the most similar between methods?\n",
     "4. Which method is the most / least sensitive to parameter selection?\n",
-    "5. If you run the same method with the same parameters multiple times, do you always get the same result?"
+    "5. If you run the same method with the same parameters multiple times, do you always get the same result?\n",
+    "\n",
+    "**Note Dan/Scott**: In one of the earlier clustering notebooks, we did more formal method of clustering efficiency, can we ask the students to actually do that as an exercise, if it is not too complicated."
    ]
   }
  ],
@@ -381,7 +385,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/exercises/Dimensionality_Reduction/03_Dimensionality_reduction_EB_data.ipynb
+++ b/exercises/Dimensionality_Reduction/03_Dimensionality_reduction_EB_data.ipynb
@@ -269,7 +269,7 @@
    "source": [
     "### Discussion\n",
     "\n",
-    "What do you notice? What does the first principle component track with? What about the second? What do you think the higher PCs represent? What does that mean?\n",
+    "What do you notice? What does the *first* principle component track with? What about the *second*? What do you think the higher PCs represent? What does that mean?\n",
     "\n",
     "Why did we plot gene expression on the first two PCs?\n",
     "\n",
@@ -415,6 +415,8 @@
     "\n",
     "Now, take some time in your groups to think of some pros and cons of using tSNE. What recommendations would you give to a new user who wants to know which parameters to try?\n",
     "\n",
+    "**Note Dan/Scott**: The Discussion sections worked beautifully IRL, because you could look around.  Online format, this probably needs to be more formalized.  Is there a way to force people to discuss these in the groups.  With a group of 4 it might just be possible!\n",
+    "\n",
     "#### _Breakpoint_  - once you get here, please help those around you!"
    ]
   },
@@ -428,7 +430,7 @@
     "\n",
     "UMAP's `n_neighbors` parameter describes the size of the neighborhood around each point. The `min_dist` parameter describes how tightly points can be packed together. The authors recommend values between 2 and 200 for `n_neighbors`, and between 0 and 0.99 for `min_dist`. Try a range of different values in and outside of these ranges and discuss the results with your group.\n",
     "\n",
-    "If you have some extra time, play around with the `min_dist` and `n_neighbors` parameters."
+    "Play around with the `min_dist` and `n_neighbors` parameters."
    ]
   },
   {
@@ -513,6 +515,8 @@
     "\n",
     "What are the similarities and differences between UMAP and t-SNE? Do you notice any parameter choices that seem to have similar effects between the algorithms?\n",
     "\n",
+    "**Note Dan/Scott**: This part is kind of repetitive between multiple notebooks under dimensionality reduction.  Can we move this or remove this to make the notebooks non-repetitive.\n",
+    "\n",
     "#### _Breakpoint_  - once you get here, please help those around you!"
    ]
   },
@@ -537,7 +541,7 @@
     "\n",
     "PHATE is a dimensionaltiy reduction developed by the Krishnaswamy lab for visualizing high-dimensional data. We use PHATE for *every* dataset the comes through the lab: scRNA-seq, CyTOF, gut microbiome profiles, simulated data, etc. PHATE was designed to handle noisy, non-linear relationships between data points. PHATE produces a low-dimensional representation that preserves both local and global structure in a dataset so that you can make generate hypotheses from the plot about the relationships between cells present in a dataset. Although PHATE has utility for analysis of many data modalities, we will focus on the application of PHATE for scRNA-seq analysis.\n",
     "\n",
-    "PHATE is inspired by diffusion maps [(Coifman et al. 2008.)](https://doi.org/10.1016/j.acha.2006.04.006), but include several key innovations that make it possible to generate a two or three dimensional visualization that preserves continuous relationships between cells where they exist. For a full explanation of the PHATE algorithm, please consult [the PHATE manuscript](https://doi.org/10.1101/120378)."
+    "PHATE is inspired by diffusion maps [(Coifman et al. 2008.)](https://doi.org/10.1016/j.acha.2006.04.006), but include several key innovations that make it possible to generate a two or three dimensional visualization that preserves continuous relationships between cells where they exist. For a full explanation of the PHATE algorithm, please consult [the PHATE manuscript](https://doi.org/10.1101/120378). **Note Dan/Scott Update the link to published paper**"
    ]
   },
   {
@@ -556,7 +560,9 @@
     "* `knn` : Number of nearest neighbors (default: 5). Increase this (e.g. to 20) if your PHATE embedding appears very disconnected. You should also consider increasing `k` if your dataset is extremely large (e.g. >100k cells)\n",
     "* `decay` : Alpha decay (default: 15). Decreasing `a` increases connectivity on the graph, increasing `a` decreases connectivity. This rarely needs to be tuned. Set it to `None` for a k-nearest neighbors kernel.\n",
     "* `t` : Number of times to power the operator (default: 'auto'). This is equivalent to the amount of smoothing done to the data. It is chosen automatically by default, but you can increase it if your embedding lacks structure, or decrease it if the structure looks too compact.\n",
-    "* `gamma` : Informational distance constant (default: 1). `gamma=1` gives the PHATE log potential, but other informational distances can be interesting. If most of the points seem concentrated in one section of the plot, you can try `gamma=0`."
+    "* `gamma` : Informational distance constant (default: 1). `gamma=1` gives the PHATE log potential, but other informational distances can be interesting. If most of the points seem concentrated in one section of the plot, you can try `gamma=0`.\n",
+    "\n",
+    "**Note Dan/Scott**: Havent the names of some parameters changed in the final version.  I only remember this vaguely, please ignore if it is not accurate."
    ]
   },
   {
@@ -689,7 +695,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/exercises/Dimensionality_Reduction/04_Simulated_Data.ipynb
+++ b/exercises/Dimensionality_Reduction/04_Simulated_Data.ipynb
@@ -17,8 +17,7 @@
     "\n",
     "Splatter, [Zappia L, et al. Genome Biology. 2017](https://doi.org/10.1186/s13059-017-1305-0), is a tool for simulating single-cell RNA-sequencing data with a known topology. Splatter has two main modes: \"paths\" and \"groups.\" Because we're interested in generating data with a known trajectory structure, we are going to use the `paths` mode.\n",
     "\n",
-    "Splatter has a bunch of other parameters you can choose from, and if you have time, feel free to play around with the various options.\n",
-    "\n"
+    "Splatter has a bunch of other parameters you can choose from, and if you have time, feel free to play around with the various options.\n"
    ]
   },
   {
@@ -87,7 +86,7 @@
    "source": [
     "### Generating simulated data\n",
     "\n",
-    "Unfortunately, Splatter is only implemented in R. Fortunately, we provide a wrapper in the `scprep.run` module. You can call Splatter from Python using [`scprep.run.SplatSimulate()`](https://scprep.readthedocs.io/en/stable/reference.html#scprep.run.SplatSimulate)."
+    "Splatter is only implemented in R. Fortunately, we provide a wrapper in the `scprep.run` module. You can call Splatter from Python using [`scprep.run.SplatSimulate()`](https://scprep.readthedocs.io/en/stable/reference.html#scprep.run.SplatSimulate)."
    ]
   },
   {
@@ -240,7 +239,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/exercises/Imputation/Imputation.Splatter.Groups.ipynb
+++ b/exercises/Imputation/Imputation.Splatter.Groups.ipynb
@@ -61,8 +61,7 @@
     "\n",
     "Splatter, [Zappia L, et al. Genome Biology. 2017](https://doi.org/10.1186/s13059-017-1305-0), is a tool for simulating single-cell RNA-sequencing data with a known topology. Splatter has two main modes: \"paths\" and \"groups.\" Because we're interested in generating data with a known trajectory structure, we are going to use the `paths` mode.\n",
     "\n",
-    "Splatter has a bunch of other parameters you can choose from, and if you have time, feel free to play around with the various options.\n",
-    "\n"
+    "Splatter has a bunch of other parameters you can choose from, feel free to play around with the various options.\n"
    ]
   },
   {
@@ -71,7 +70,7 @@
    "source": [
     "#### Generating simulated data\n",
     "\n",
-    "Unfortunately, Splatter is only implemented in R. Fortunately, we provide a wrapper in the `scprep.run` module. You can call Splatter from Python using [`scprep.run.SplatSimulate()`](https://scprep.readthedocs.io/en/stable/reference.html#scprep.run.SplatSimulate)."
+    "Splatter is only implemented in R. Fortunately, we provide a wrapper in the `scprep.run` module. You can call Splatter from Python using [`scprep.run.SplatSimulate()`](https://scprep.readthedocs.io/en/stable/reference.html#scprep.run.SplatSimulate)."
    ]
   },
   {
@@ -191,7 +190,7 @@
    "source": [
     "#### Visualizing the data\n",
     "\n",
-    "Splatter is designed to generate data that can be easily visualized using PCA. If you have time, try to visualize the data using other tools from our visualization module."
+    "Splatter is designed to generate data that can be easily visualized using PCA. Try to visualize the data using other tools from our visualization module."
    ]
   },
   {
@@ -555,7 +554,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The 3 note books here look very confusing.  Although the `splatter` notebooks have "Groups", and "Paths" in the names, they both use "paths" in the code. The Worm data notebook looks incomplete.  It ends with a table, and there is no explanation at the end.  The graphs generated in the `splatter` notebooks are identical.  Also it seems that the notebooks are under use, because as soon as I opened them there were errors and red boxes. @dburkhardt and @scottgigante should take a look and make sure that the notebooks are clean before accepting this `pull request`.