### PR TITLE
Fixed bugs in PHATE exercise of Day 1 beginner notebook

### DIFF
--- a/exercises/Preprocessing/notebooks/00_Loading_and_preprocessing_scRNAseq_data.ipynb
+++ b/exercises/Preprocessing/notebooks/00_Loading_and_preprocessing_scRNAseq_data.ipynb
@@ -1148,13 +1148,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import phate\n",
+    "\n",
     "filenames = [\"T0_1A\", \"T2_3B\", \"T4_5C\", \"T6_7D\", \"T8_9E\"]\n",
     "\n",
     "# load batches\n",
     "data_batches = []\n",
     "for filename in filenames:\n",
     "    data_batches.append(scprep.io.load_10X(os.path.join(download_path, \"scRNAseq\", filename), \n",
-    "                                           sparse=sparse, gene_labels='both')\n",
+    "                                           sparse=sparse, gene_labels='both'))\n",
     "\n",
     "# library size filter\n",
     "data = []\n",
@@ -1262,7 +1264,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixed bugs in PHATE exercise of Day 1 beginner notebook: phate was not imported, and a right parenthesis was missing.